### PR TITLE
Fix admin session handling and local database setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ psycopg2-binary
 python-dotenv
 gunicorn
 supabase
+requests
 

--- a/src/main.py
+++ b/src/main.py
@@ -33,7 +33,9 @@ if database_url:
     app.config['SQLALCHEMY_DATABASE_URI'] = database_url
 else:
     # Usar SQLite local (desenvolvimento)
-    app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'database', 'app.db')}"
+    db_dir = os.path.join(os.path.dirname(__file__), 'database')
+    os.makedirs(db_dir, exist_ok=True)
+    app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(db_dir, 'app.db')}"
 
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -34,7 +34,9 @@ function hideLoginModal() {
 // Authentication functions
 async function checkAuth() {
     try {
-        const response = await fetch('/api/check-auth');
+        const response = await fetch('/api/check-auth', {
+            credentials: 'same-origin'
+        });
         const data = await response.json();
         
         if (data.authenticated) {
@@ -60,7 +62,8 @@ async function login() {
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify({ username, password })
+            body: JSON.stringify({ username, password }),
+            credentials: 'same-origin'
         });
         
         const data = await response.json();
@@ -80,7 +83,7 @@ async function login() {
 
 async function logout() {
     try {
-        await fetch('/api/logout', { method: 'POST' });
+        await fetch('/api/logout', { method: 'POST', credentials: 'same-origin' });
         hideAdminSection();
         showAlert('Logout realizado com sucesso!', 'info');
     } catch (error) {
@@ -104,7 +107,7 @@ async function loadEquivalencias() {
     showLoading(true);
     
     try {
-        const response = await fetch('/api/equivalencias');
+        const response = await fetch('/api/equivalencias', { credentials: 'same-origin' });
         const data = await response.json();
         
         if (response.ok) {
@@ -159,7 +162,7 @@ function displayEquivalencias(equivalencias) {
 
 async function loadAdminTable() {
     try {
-        const response = await fetch('/api/equivalencias');
+        const response = await fetch('/api/equivalencias', { credentials: 'same-origin' });
         const data = await response.json();
         
         if (response.ok) {
@@ -219,13 +222,15 @@ async function handleFormSubmit(e) {
             response = await fetch(`/api/equivalencias/${currentEditId}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(formData)
+                body: JSON.stringify(formData),
+                credentials: 'same-origin'
             });
         } else {
             response = await fetch('/api/equivalencias', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(formData)
+                body: JSON.stringify(formData),
+                credentials: 'same-origin'
             });
         }
         
@@ -286,7 +291,8 @@ async function deleteEquivalencia(id) {
     
     try {
         const response = await fetch(`/api/equivalencias/${id}`, {
-            method: 'DELETE'
+            method: 'DELETE',
+            credentials: 'same-origin'
         });
         
         const data = await response.json();


### PR DESCRIPTION
## Summary
- ensure SQLite database folder exists before initializing
- send credentials with frontend fetch calls so admin session persists
- add requests dependency for testing

## Testing
- `curl -s http://localhost:5000/api/info`
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"username":"admin","password":"adm4125"}' http://localhost:5000/api/login -c cookies.txt && curl -s -b cookies.txt http://localhost:5000/api/check-auth`
- `curl -s -X POST -H 'Content-Type: application/json' -b cookies.txt -d '{"disciplina_adm":"Disciplina A","codigo_adm":"ADM101","ch_adm":"60","disciplina_equiv":"Disciplina B","codigo_equiv":"EQUIV201","curso_equiv":"Curso X","ch_equiv":"60","justificativa":"Test"}' http://localhost:5000/api/equivalencias`
- `python teste_login.py` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68ac58c7b4e4832bb8a0ca28ee7c7ed3

## Resumo por Sourcery

Corrige o tratamento da sessão de administrador incluindo credenciais nas chamadas fetch do frontend, garante que o diretório do banco de dados SQLite local seja criado antes da inicialização e adiciona a dependência requests para testes

Correções de Bugs:
- Inclui credenciais nas chamadas fetch do frontend para persistir a sessão de administrador
- Garante que a pasta do banco de dados SQLite local exista antes de inicializar para evitar erros

Compilação:
- Adiciona requests ao requirements.txt para habilitar scripts de teste Python

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix admin session handling by including credentials in frontend fetch calls, ensure local SQLite database directory is created before initialization, and add requests dependency for testing

Bug Fixes:
- Include credentials with frontend fetch calls to persist admin session
- Ensure local SQLite database folder exists before initializing to prevent errors

Build:
- Add requests to requirements.txt to enable Python test scripts

</details>