### PR TITLE
fix: maintain session in login test

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Execute o script de teste para verificar se tudo está funcionando:
 python teste_login.py
 ```
 
+> O script usa `requests.Session` para manter cookies entre as requisições e validar corretamente a autenticação.
+
 Para testar em servidor remoto:
 ```bash
 python teste_login.py http://seu-dominio.com

--- a/teste_login.py
+++ b/teste_login.py
@@ -9,14 +9,16 @@ import sys
 
 def testar_login(base_url="http://localhost:5000"):
     """Testa o sistema de login"""
-    
+
+    session = requests.Session()
+
     print("🧪 Testando Sistema de Login - Equivalências UFSM")
     print("=" * 50)
-    
+
     # Teste 1: Verificar se o servidor está rodando
     print("1. Testando conectividade com o servidor...")
     try:
-        response = requests.get(f"{base_url}/api/info", timeout=5)
+        response = session.get(f"{base_url}/api/info", timeout=5)
         if response.status_code == 200:
             info = response.json()
             print(f"✅ Servidor online - {info.get('name', 'Sistema')}")
@@ -33,7 +35,7 @@ def testar_login(base_url="http://localhost:5000"):
     # Teste 2: Verificar autenticação inicial
     print("\n2. Verificando status de autenticação...")
     try:
-        response = requests.get(f"{base_url}/api/check-auth")
+        response = session.get(f"{base_url}/api/check-auth")
         if response.status_code == 200:
             auth_data = response.json()
             if auth_data.get('authenticated'):
@@ -53,7 +55,7 @@ def testar_login(base_url="http://localhost:5000"):
     }
     
     try:
-        response = requests.post(
+        response = session.post(
             f"{base_url}/api/login",
             json=login_data,
             headers={"Content-Type": "application/json"}
@@ -67,7 +69,7 @@ def testar_login(base_url="http://localhost:5000"):
             
             # Verificar se a sessão foi criada
             print("\n4. Verificando se a sessão foi criada...")
-            auth_response = requests.get(f"{base_url}/api/check-auth")
+            auth_response = session.get(f"{base_url}/api/check-auth")
             if auth_response.status_code == 200:
                 auth_data = auth_response.json()
                 if auth_data.get('authenticated'):
@@ -97,7 +99,7 @@ def testar_login(base_url="http://localhost:5000"):
     }
     
     try:
-        response = requests.post(
+        response = session.post(
             f"{base_url}/api/login",
             json=wrong_login_data,
             headers={"Content-Type": "application/json"}
@@ -114,12 +116,12 @@ def testar_login(base_url="http://localhost:5000"):
     # Teste 5: Testar logout
     print("\n6. Testando logout...")
     try:
-        response = requests.post(f"{base_url}/api/logout")
+        response = session.post(f"{base_url}/api/logout")
         if response.status_code == 200:
             print("✅ Logout realizado com sucesso")
             
             # Verificar se a sessão foi removida
-            auth_response = requests.get(f"{base_url}/api/check-auth")
+            auth_response = session.get(f"{base_url}/api/check-auth")
             if auth_response.status_code == 200:
                 auth_data = auth_response.json()
                 if not auth_data.get('authenticated'):

--- a/teste_login.py
+++ b/teste_login.py
@@ -1,145 +1,164 @@
 #!/usr/bin/env python3
-"""
-Script de teste para verificar se a correção do login está funcionando
-"""
+"""Ferramenta de verificação do fluxo de autenticação."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
 
 import requests
-import json
-import sys
 
-def testar_login(base_url="http://localhost:5000"):
-    """Testa o sistema de login"""
+
+def check_server(session: requests.Session, base_url: str) -> bool:
+    """Verifica se o servidor está respondendo e se a sessão está configurada."""
+
+    print("1. Testando conectividade com o servidor...")
+    try:
+        response = session.get(f"{base_url}/api/info", timeout=5)
+    except requests.exceptions.RequestException as exc:
+        print(f"❌ Erro de conectividade: {exc}")
+        print("   Certifique-se de que o servidor está rodando em", base_url)
+        return False
+
+    if response.status_code != 200:
+        print(f"❌ Servidor retornou status {response.status_code}")
+        return False
+
+    info: dict[str, Any] = response.json()
+    print(f"✅ Servidor online - {info.get('name', 'Sistema')}")
+    print(f"   Versão: {info.get('version', 'N/A')}")
+    print(f"   Sessões: {'✅' if info.get('session_configured') else '❌'}")
+    return True
+
+
+def check_authentication(session: requests.Session, base_url: str) -> None:
+    """Exibe o estado de autenticação da sessão atual."""
+
+    print("\n2. Verificando status de autenticação...")
+    try:
+        response = session.get(f"{base_url}/api/check-auth")
+    except requests.exceptions.RequestException as exc:
+        print(f"❌ Erro na verificação: {exc}")
+        return
+
+    if response.status_code == 200:
+        auth_data = response.json()
+        if auth_data.get("authenticated"):
+            print(f"✅ Usuário já autenticado: {auth_data.get('username')}")
+        else:
+            print("✅ Usuário não autenticado (esperado)")
+    else:
+        print(f"❌ Erro ao verificar autenticação: {response.status_code}")
+
+
+def login(session: requests.Session, base_url: str, username: str, password: str) -> bool:
+    """Realiza o login e confirma se a sessão foi criada."""
+
+    print("\n3. Testando login com credenciais corretas...")
+    payload = {"username": username, "password": password}
+    try:
+        response = session.post(
+            f"{base_url}/api/login",
+            json=payload,
+            headers={"Content-Type": "application/json"},
+        )
+    except requests.exceptions.RequestException as exc:
+        print(f"❌ Erro na requisição de login: {exc}")
+        return False
+
+    if response.status_code != 200:
+        print(f"❌ Login falhou com status {response.status_code}")
+        try:
+            error_data = response.json()
+            print(f"   Erro: {error_data.get('error', 'Erro desconhecido')}")
+        except Exception:
+            print(f"   Resposta: {response.text}")
+        return False
+
+    result = response.json()
+    print("✅ Login bem-sucedido!")
+    print(f"   Usuário: {result.get('username')}")
+    print(f"   Mensagem: {result.get('message')}")
+
+    print("\n4. Verificando se a sessão foi criada...")
+    auth_response = session.get(f"{base_url}/api/check-auth")
+    if auth_response.status_code == 200:
+        auth_data = auth_response.json()
+        if auth_data.get("authenticated"):
+            print(f"✅ Sessão criada com sucesso para: {auth_data.get('username')}")
+            return True
+        print("❌ Sessão não foi criada")
+    else:
+        print(f"❌ Erro ao verificar sessão: {auth_response.status_code}")
+    return False
+
+
+def login_incorreto(session: requests.Session, base_url: str) -> None:
+    """Verifica o comportamento do login com credenciais inválidas."""
+
+    print("\n5. Testando login com credenciais incorretas...")
+    wrong_payload = {"username": "admin", "password": "senha_errada"}
+    try:
+        response = session.post(
+            f"{base_url}/api/login",
+            json=wrong_payload,
+            headers={"Content-Type": "application/json"},
+        )
+    except requests.exceptions.RequestException as exc:
+        print(f"❌ Erro no teste de credenciais incorretas: {exc}")
+        return
+
+    if response.status_code == 401:
+        print("✅ Credenciais incorretas rejeitadas corretamente")
+    else:
+        print(f"❌ Resposta inesperada para credenciais incorretas: {response.status_code}")
+
+
+def logout(session: requests.Session, base_url: str) -> None:
+    """Efetua logout e confirma a remoção da sessão."""
+
+    print("\n6. Testando logout...")
+    try:
+        response = session.post(f"{base_url}/api/logout")
+    except requests.exceptions.RequestException as exc:
+        print(f"❌ Erro no teste de logout: {exc}")
+        return
+
+    if response.status_code == 200:
+        print("✅ Logout realizado com sucesso")
+        auth_response = session.get(f"{base_url}/api/check-auth")
+        if auth_response.status_code == 200:
+            auth_data = auth_response.json()
+            if not auth_data.get("authenticated"):
+                print("✅ Sessão removida com sucesso")
+            else:
+                print("❌ Sessão ainda ativa após logout")
+    else:
+        print(f"❌ Erro no logout: {response.status_code}")
+
+
+def testar_login(base_url: str = "http://localhost:5000") -> bool:
+    """Executa todos os testes de login."""
 
     session = requests.Session()
 
     print("🧪 Testando Sistema de Login - Equivalências UFSM")
     print("=" * 50)
 
-    # Teste 1: Verificar se o servidor está rodando
-    print("1. Testando conectividade com o servidor...")
-    try:
-        response = session.get(f"{base_url}/api/info", timeout=5)
-        if response.status_code == 200:
-            info = response.json()
-            print(f"✅ Servidor online - {info.get('name', 'Sistema')}")
-            print(f"   Versão: {info.get('version', 'N/A')}")
-            print(f"   Sessões: {'✅' if info.get('session_configured') else '❌'}")
-        else:
-            print(f"❌ Servidor retornou status {response.status_code}")
-            return False
-    except requests.exceptions.RequestException as e:
-        print(f"❌ Erro de conectividade: {e}")
-        print("   Certifique-se de que o servidor está rodando em", base_url)
+    if not check_server(session, base_url):
         return False
-    
-    # Teste 2: Verificar autenticação inicial
-    print("\n2. Verificando status de autenticação...")
-    try:
-        response = session.get(f"{base_url}/api/check-auth")
-        if response.status_code == 200:
-            auth_data = response.json()
-            if auth_data.get('authenticated'):
-                print(f"✅ Usuário já autenticado: {auth_data.get('username')}")
-            else:
-                print("✅ Usuário não autenticado (esperado)")
-        else:
-            print(f"❌ Erro ao verificar autenticação: {response.status_code}")
-    except requests.exceptions.RequestException as e:
-        print(f"❌ Erro na verificação: {e}")
-    
-    # Teste 3: Testar login com credenciais corretas
-    print("\n3. Testando login com credenciais corretas...")
-    login_data = {
-        "username": "admin",
-        "password": "adm4125"
-    }
-    
-    try:
-        response = session.post(
-            f"{base_url}/api/login",
-            json=login_data,
-            headers={"Content-Type": "application/json"}
-        )
-        
-        if response.status_code == 200:
-            result = response.json()
-            print(f"✅ Login bem-sucedido!")
-            print(f"   Usuário: {result.get('username')}")
-            print(f"   Mensagem: {result.get('message')}")
-            
-            # Verificar se a sessão foi criada
-            print("\n4. Verificando se a sessão foi criada...")
-            auth_response = session.get(f"{base_url}/api/check-auth")
-            if auth_response.status_code == 200:
-                auth_data = auth_response.json()
-                if auth_data.get('authenticated'):
-                    print(f"✅ Sessão criada com sucesso para: {auth_data.get('username')}")
-                else:
-                    print("❌ Sessão não foi criada")
-                    return False
-            
-        else:
-            print(f"❌ Login falhou com status {response.status_code}")
-            try:
-                error_data = response.json()
-                print(f"   Erro: {error_data.get('error', 'Erro desconhecido')}")
-            except:
-                print(f"   Resposta: {response.text}")
-            return False
-            
-    except requests.exceptions.RequestException as e:
-        print(f"❌ Erro na requisição de login: {e}")
+    check_authentication(session, base_url)
+    if not login(session, base_url, "admin", "adm4125"):
         return False
-    
-    # Teste 4: Testar login com credenciais incorretas
-    print("\n5. Testando login com credenciais incorretas...")
-    wrong_login_data = {
-        "username": "admin",
-        "password": "senha_errada"
-    }
-    
-    try:
-        response = session.post(
-            f"{base_url}/api/login",
-            json=wrong_login_data,
-            headers={"Content-Type": "application/json"}
-        )
-        
-        if response.status_code == 401:
-            print("✅ Credenciais incorretas rejeitadas corretamente")
-        else:
-            print(f"❌ Resposta inesperada para credenciais incorretas: {response.status_code}")
-            
-    except requests.exceptions.RequestException as e:
-        print(f"❌ Erro no teste de credenciais incorretas: {e}")
-    
-    # Teste 5: Testar logout
-    print("\n6. Testando logout...")
-    try:
-        response = session.post(f"{base_url}/api/logout")
-        if response.status_code == 200:
-            print("✅ Logout realizado com sucesso")
-            
-            # Verificar se a sessão foi removida
-            auth_response = session.get(f"{base_url}/api/check-auth")
-            if auth_response.status_code == 200:
-                auth_data = auth_response.json()
-                if not auth_data.get('authenticated'):
-                    print("✅ Sessão removida com sucesso")
-                else:
-                    print("❌ Sessão ainda ativa após logout")
-        else:
-            print(f"❌ Erro no logout: {response.status_code}")
-            
-    except requests.exceptions.RequestException as e:
-        print(f"❌ Erro no teste de logout: {e}")
-    
+    login_incorreto(session, base_url)
+    logout(session, base_url)
+
     print("\n" + "=" * 50)
     print("🎉 Teste concluído! Se todos os itens estão ✅, a correção funcionou.")
     return True
 
+
 if __name__ == "__main__":
-    # Permitir URL customizada como argumento
     url = sys.argv[1] if len(sys.argv) > 1 else "http://localhost:5000"
     testar_login(url)
 


### PR DESCRIPTION
## Summary
- ensure login test uses a persistent session so cookies are kept between requests
- document the session-based login test in README

## Testing
- `python src/main.py >/tmp/server.log 2>&1 &`
- `python teste_login.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad15725530832bb1aba04967122827

## Resumo por Sourcery

Utiliza uma sessão HTTP persistente no teste de login para manter os cookies entre as requisições e atualiza o README com esta mudança

Documentação:
- Documenta o uso do teste de login baseado em sessão em README.md

Testes:
- Refatora o teste de login para usar requests.Session para persistência de cookies entre as requisições

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use a persistent HTTP session in the login test to maintain cookies across requests and update the README with this change

Documentation:
- Document session-based login test usage in README.md

Tests:
- Refactor login test to use requests.Session for cookie persistence across requests

</details>